### PR TITLE
Generate sample unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - npm link generator-jhipster-blueprint
   - yo jhipster-blueprint default
   - npm install
-  # - npm test
+  - npm test
   - npm link
   - npm link generator-jhipster
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ script:
   - npm link generator-jhipster-blueprint
   - yo jhipster-blueprint default
   - npm install
-  - npm test
   - npm link
   - npm link generator-jhipster
+  - npm test
 
   # force no insight
   - mkdir -p "$HOME"/.config/configstore/

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -231,7 +231,9 @@ module.exports = class extends Generator {
             this.subGenerator = subGenerator;
             this.template('test/_subgen.spec.ejs', `test/${subGenerator}.spec.js`);
         });
-        this.template('test/templates/ngx-blueprint/.yo-rc.json.ejs', 'test/templates/ngx-blueprint/.yo-rc.json');
+        if (this.blueprintSubs.find(subGen => ['entity', 'spring-controller', 'spring-service'].includes(subGen))) {
+            this.template('test/templates/ngx-blueprint/.yo-rc.json.ejs', 'test/templates/ngx-blueprint/.yo-rc.json');
+        }
     }
 
     end() {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -226,6 +226,12 @@ module.exports = class extends Generator {
             // copy files for the spring-service generator
             this.template('generators/spring-service/_index.js', 'generators/spring-service/index.js');
         }
+
+        this.blueprintSubs.filter(subGen => !subGen.startsWith('entity-')).forEach(subGenerator => {
+            this.subGenerator = subGenerator;
+            this.template('test/_subgen.spec.ejs', `test/${subGenerator}.spec.js`);
+        });
+        this.template('test/templates/ngx-blueprint/.yo-rc.json.ejs', 'test/templates/ngx-blueprint/.yo-rc.json');
     }
 
     end() {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -38,7 +38,7 @@
     "semver": "5.5.0",
     "shelljs": "0.8.2",
     "through2": "2.0.3",
-    "generator-jhipster": ">=5.0.0",
+    "generator-jhipster": ">=5.4.0",
     "yeoman-environment": "2.3.0",
     "yeoman-generator": "2.0.5"
   },

--- a/generators/app/templates/eslintrc.json
+++ b/generators/app/templates/eslintrc.json
@@ -28,5 +28,11 @@
         "no-multi-assign": "off",
         "no-param-reassign": "off",
         "no-shadow": "off"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["test/**/*.js"],
+            "env": { "mocha": true }
+        }
+    ]
 }

--- a/generators/app/templates/test/_subgen.spec.ejs
+++ b/generators/app/templates/test/_subgen.spec.ejs
@@ -16,7 +16,7 @@ describe('Subgenerator <%= subGenerator %> of <%= moduleName %> JHipster bluepri
                 })
 <%_ } _%>
                 .withOptions({
-                    'from-cli': true, skipInstall: true, blueprint: '<%= subGenerator %>', skipChecks: true
+                    'from-cli': true, skipInstall: true, blueprint: '<%= moduleName %>', skipChecks: true
                 })
                 .withGenerators([
                     [

--- a/generators/app/templates/test/_subgen.spec.ejs
+++ b/generators/app/templates/test/_subgen.spec.ejs
@@ -1,0 +1,66 @@
+const path = require('path');
+<%_ if (['entity', 'spring-controller', 'spring-service'].includes(subGenerator)) { _%>
+const fse = require('fs-extra');
+<%_ } _%>
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+describe('Subgenerator <%= subGenerator %> of <%= moduleName %> JHipster blueprint', () => {
+    describe('Sample test', () => {
+        before((done) => {
+            helpers
+                .run('generator-jhipster/generators/<%= subGenerator %>')
+<%_ if (['entity', 'spring-controller', 'spring-service'].includes(subGenerator)) { _%>
+                .inTmpDir((dir) => {
+                    fse.copySync(path.join(__dirname, '../test/templates/ngx-blueprint'), dir);
+                })
+<%_ } _%>
+                .withOptions({
+                    'from-cli': true, skipInstall: true, blueprint: '<%= subGenerator %>', skipChecks: true
+                })
+                .withGenerators([
+                    [
+                        require('../generators/<%= subGenerator %>/index.js'), // eslint-disable-line global-require
+                        'jhipster-<%= moduleName %>:<%= subGenerator %>',
+                        path.join(__dirname, '../generators/<%= subGenerator %>/index.js')
+                    ]
+                ])
+<%_ if (['entity', 'spring-controller', 'spring-service'].includes(subGenerator)) { _%>
+                .withArguments(['foo'])
+<%_ } _%>
+                .withPrompts({
+<%_ if (subGenerator === 'entity') { _%>
+                    fieldAdd: false,
+                    relationshipAdd: false,
+                    dto: 'no',
+                    service: 'no',
+                    pagination: 'infinite-scroll'
+<%_ } else if (subGenerator === 'spring-service') { _%>
+                    useInterface: false
+<%_ } else if (subGenerator === 'spring-controller') { _%>
+                    actionAdd: false
+<%_ } else { _%>
+                    baseName: 'sampleMysql',
+                    packageName: 'com.mycompany.myapp',
+                    applicationType: 'monolith',
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    cacheProvider: 'ehcache',
+                    authenticationType: 'session',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr', 'de'],
+                    buildTool: 'maven',
+                    rememberMeKey: '2bb60a80889aa6e6767e9ccd8714982681152aa5'
+<%_ } _%>
+                })
+                .on('end', done);
+        });
+
+        it('it works', () => {
+            // Adds your tests here
+            assert.textEqual('Write your own tests!', 'Write your own tests!');
+        });
+    });
+});

--- a/generators/app/templates/test/templates/ngx-blueprint/.yo-rc.json.ejs
+++ b/generators/app/templates/test/templates/ngx-blueprint/.yo-rc.json.ejs
@@ -1,0 +1,48 @@
+{
+    "generator-jhipster-<%= moduleName %>": {
+        "promptValues": {
+            "packageName": "com.mycompany.myapp"
+        },
+        "applicationType": "monolith",
+        "baseName": "jhipsterBlueprint",
+        "packageName": "com.mycompany.myapp",
+        "packageFolder": "com/mycompany/myapp",
+        "serverPort": "8080",
+        "authenticationType": "jwt",
+        "cacheProvider": "ehcache",
+        "enableHibernateCache": true,
+        "websocket": false,
+        "databaseType": "sql",
+        "devDatabaseType": "h2Disk",
+        "prodDatabaseType": "mysql",
+        "searchEngine": false,
+        "messageBroker": false,
+        "serviceDiscoveryType": false,
+        "buildTool": "maven",
+        "enableSwaggerCodegen": false,
+        "jwtSecretKey": "147e04cf224f52908a60d7a2902e19e0648d0a8c52503b4624f1708478dd29ba2885a9bb823c85873a76b27964a90e22f1e8",
+        "clientFramework": "angularX",
+        "useSass": false,
+        "clientPackageManager": "npm"
+    },
+    "generator-jhipster": {
+        "promptValues": {
+            "nativeLanguage": "en"
+        },
+        "applicationType": "monolith",
+        "baseName": "jhipsterBlueprint",
+        "testFrameworks": [
+            "gatling",
+            "protractor"
+        ],
+        "jhiPrefix": "jhi",
+        "enableTranslation": true,
+        "clientPackageManager": "npm",
+        "nativeLanguage": "en",
+        "languages": [
+            "en",
+            "fr"
+        ],
+        "blueprint": "generator-jhipster-<%= moduleName %>"
+    }
+}

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -13,7 +13,8 @@ const expectedFiles = {
         '.gitignore',
         '.travis.yml',
         'package.json',
-        'README.md'
+        'README.md',
+        'test/templates/ngx-blueprint/.yo-rc.json'
     ],
     client: [
         'generators/client/index.js',
@@ -35,7 +36,7 @@ const ALL_SUBGENS = ['client', 'entity', 'entity-client', 'entity-i18n', 'entity
 
 describe('JHipster generator blueprint', () => {
     describe('default configuration no license', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -59,12 +60,13 @@ describe('JHipster generator blueprint', () => {
         ALL_SUBGENS.forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
             });
         });
     });
 
     describe('default configuration license Apache', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -90,12 +92,13 @@ describe('JHipster generator blueprint', () => {
         ALL_SUBGENS.forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
             });
         });
     });
 
     describe('default configuration license GNU GPLv3', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -121,12 +124,13 @@ describe('JHipster generator blueprint', () => {
         ALL_SUBGENS.forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
             });
         });
     });
 
     describe('default configuration license MIT', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -152,12 +156,13 @@ describe('JHipster generator blueprint', () => {
         ALL_SUBGENS.forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
             });
         });
     });
 
     describe('generate client and entity blueprint templates only', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -179,18 +184,21 @@ describe('JHipster generator blueprint', () => {
         });
         it('generates client files', () => {
             assert.file(expectedFiles.client);
+            assert.file(['test/client.spec.js']);
         });
         it('generates entity files', () => {
             assert.file(expectedFiles.entity);
+            assert.file(['test/entity.spec.js']);
         });
-        ['entity-client', 'entity-i18n', 'entity-server', 'server', 'spring-controller', 'spring-service'].forEach(subGen => {
+        ALL_SUBGENS.filter(subGen => !['client', 'entity'].includes(subGen)).forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
             });
         });
     });
     describe('generate all blueprint templates only', () => {
-        beforeEach(done => {
+        before(done => {
             helpers
                 .run(path.join(__dirname, '../generators/app'))
                 .withPrompts({
@@ -214,6 +222,11 @@ describe('JHipster generator blueprint', () => {
             it(`generates ${subGen} files`, () => {
                 assert.file(expectedFiles[subGen]);
             });
+            if (!subGen.startsWith('entity-')) {
+                it(`generates ${subGen} test files`, () => {
+                    assert.file([`test/${subGen}.spec.js`]);
+                });
+            }
         });
     });
 });

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -13,8 +13,7 @@ const expectedFiles = {
         '.gitignore',
         '.travis.yml',
         'package.json',
-        'README.md',
-        'test/templates/ngx-blueprint/.yo-rc.json'
+        'README.md'
     ],
     client: [
         'generators/client/index.js',
@@ -22,6 +21,7 @@ const expectedFiles = {
         'generators/client/prompts.js',
         'generators/client/templates/_dummy.txt'
     ],
+    templates: ['test/templates/ngx-blueprint/.yo-rc.json'],
     entity: ['generators/entity/index.js'],
     'entity-client': ['generators/entity-client/index.js'],
     'entity-server': ['generators/entity-server/index.js'],
@@ -61,6 +61,7 @@ describe('JHipster generator blueprint', () => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
                 assert.noFile([`test/${subGen}.spec.js`]);
+                assert.noFile(expectedFiles.templates);
             });
         });
     });
@@ -93,6 +94,7 @@ describe('JHipster generator blueprint', () => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
                 assert.noFile([`test/${subGen}.spec.js`]);
+                assert.noFile(expectedFiles.templates);
             });
         });
     });
@@ -125,6 +127,7 @@ describe('JHipster generator blueprint', () => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
                 assert.noFile([`test/${subGen}.spec.js`]);
+                assert.noFile(expectedFiles.templates);
             });
         });
     });
@@ -157,6 +160,7 @@ describe('JHipster generator blueprint', () => {
             it(`doesn't generate ${subGen} files`, () => {
                 assert.noFile(expectedFiles[subGen]);
                 assert.noFile([`test/${subGen}.spec.js`]);
+                assert.noFile(expectedFiles.templates);
             });
         });
     });
@@ -189,6 +193,7 @@ describe('JHipster generator blueprint', () => {
         it('generates entity files', () => {
             assert.file(expectedFiles.entity);
             assert.file(['test/entity.spec.js']);
+            assert.file(expectedFiles.templates);
         });
         ALL_SUBGENS.filter(subGen => !['client', 'entity'].includes(subGen)).forEach(subGen => {
             it(`doesn't generate ${subGen} files`, () => {
@@ -197,6 +202,43 @@ describe('JHipster generator blueprint', () => {
             });
         });
     });
+
+    describe('generate server blueprint templates only', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../generators/app'))
+                .withPrompts({
+                    moduleName: 'hello-world',
+                    moduleDescription: 'hello world',
+                    blueprintSubs: ['server'],
+                    hookCallback: 'app',
+                    githubName: 'githubName',
+                    authorName: 'authorName',
+                    authorEmail: 'mail@mail',
+                    authorUrl: 'authorUrl',
+                    license: 'no'
+                })
+                .on('end', done);
+        });
+
+        it('generates default files', () => {
+            assert.file(expectedFiles.module);
+        });
+        it('generates server files', () => {
+            assert.file(expectedFiles.server);
+            assert.file(['test/server.spec.js']);
+        });
+        it("doesn't generate unecessary template folder", () => {
+            assert.noFile(expectedFiles.templates);
+        });
+        ALL_SUBGENS.filter(subGen => subGen !== 'server').forEach(subGen => {
+            it(`doesn't generate ${subGen} files`, () => {
+                assert.noFile(expectedFiles[subGen]);
+                assert.noFile([`test/${subGen}.spec.js`]);
+            });
+        });
+    });
+
     describe('generate all blueprint templates only', () => {
         before(done => {
             helpers


### PR DESCRIPTION
Excepted for entity-* subgenerators since they can't be easily tested with unit tests.
Fixes #7 

