### PR TITLE
Add CLI to blueprint generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -186,6 +186,8 @@ module.exports = class extends Generator {
         this.template('gitignore', '.gitignore');
         this.template('_travis.yml', '.travis.yml');
         this.template('_package.json', 'package.json');
+        this.template('cli/app.js', 'cli/app.js');
+        this.template('cli/utils.js', 'cli/utils.js');
         if (this.license === 'apache') {
             this.template('_LICENSE_APACHE', 'LICENSE');
         } else if (this.license === 'gpl') {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -14,8 +14,12 @@
     "url": "<%= authorUrl %>"
   },
   "files": [
-    "generators"
+    "generators",
+      "cli"
   ],
+  "bin": {
+    "jhipster-<%= moduleName %>": "./cli/app.js"
+  },
   "main": "generators/app/index.js",
   "repository": {
     "type": "git",

--- a/generators/app/templates/cli/app.js
+++ b/generators/app/templates/cli/app.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const fork = require('child_process').fork;
+const utils = require('./utils');
+
+const jhipsterPath = utils.generateJHipsterPath('../node_modules/generator-jhipster/cli/jhipster');
+const args = utils.initArguments('--blueprint', '<%= moduleName %>');
+
+fork(jhipsterPath, args);

--- a/generators/app/templates/cli/utils.js
+++ b/generators/app/templates/cli/utils.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const p = require('path');
+
+function generateJHipsterPath(relativePath) {
+    const absolutePath = p.join(__dirname, relativePath);
+    return p.normalize(absolutePath);
+}
+
+function initArguments(...args) {
+    const inputArgs = _removeNodeArgsInProcessArgv();
+
+    return args.concat(inputArgs);
+}
+
+function _removeNodeArgsInProcessArgv() {
+    return process.argv ? process.argv.slice(2) : [];
+}
+
+module.exports = {
+    generateJHipsterPath,
+    initArguments
+};


### PR DESCRIPTION
Hi,
I did something like that for my client. I suppose it can be useful for all blueprint users.

Add a CLI for blueprints.

The idea is to force the blueprint to use the jhipster from his node_module instead of a global one.
Also we have a cool command like `jhipster-myBlueprint`and no longer use `jhipster --blueprint myBlueprint`

Of course I keep the possibility to add arguments from JHipster :
`jhipster-myBlueprint --skip-checks --skip-git` works.

